### PR TITLE
Add location model and serializer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,14 +7,16 @@ RUN apt-get update && apt-get install -y \
     python3-gdal \
     binutils libproj-dev \
  && rm -rf /var/lib/apt/lists/*
+
+ENV DOCKERIZE_VERSION v0.6.1
+RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+    && tar -C /usr/local/bin -xzvf dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+    && rm dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz
+
 RUN pip install -r production.txt
 
 ARG TEST
-ENV DOCKERIZE_VERSION v0.6.1
 RUN [ "x$TEST" = "x" ] && true || pip install -r test.txt
-RUN [ "x$TEST" = "x" ] && true || curl -L -s -o dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz
-RUN [ "x$TEST" = "x" ] && true || tar -C /usr/local/bin -xzvf dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz
-RUN [ "x$TEST" = "x" ] && true || rm dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz
 
 COPY . /code
 WORKDIR /code

--- a/Makefile
+++ b/Makefile
@@ -16,4 +16,4 @@ test: build_test
 	@docker-compose \
 		-f docker-compose.yaml \
 		-f docker-compose.test.yaml \
-		run web dockerize -timeout 20s -wait tcp://db:5432 bash -c "pytest -vv --ds=trip_app.settings.test trip_app/"
+		run web bash -c "pytest -vv --ds=trip_app.settings.test trip_app/"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,7 +18,7 @@ services:
       DB_NAME: $DB_NAME
       OPENSTREET_KEY: $OPENSTREET_KEY
       TRIP_APP_SECRET: $TRIP_APP_SECRET
-    command: python trip_app/manage.py runserver 0.0.0.0:8000
+    command: dockerize -wait tcp://db:5432 python trip_app/manage.py runserver 0.0.0.0:8000
     ports:
       - "8000:8000"
     depends_on:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -16,6 +16,8 @@ services:
       DB_USER: $DB_USER
       DB_PASS: $DB_PASS
       DB_NAME: $DB_NAME
+      OPENSTREET_KEY: $OPENSTREET_KEY
+      TRIP_APP_SECRET: $TRIP_APP_SECRET
     command: python trip_app/manage.py runserver 0.0.0.0:8000
     ports:
       - "8000:8000"

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -7,6 +7,4 @@ djangorestframework-simplejwt==4.3.0
 PyJWT==1.7.1
 djangorestframework-gis==0.14
 django-filter==2.2.0
-
-
-
+geopy==1.20.0

--- a/trip_app/core/utils.py
+++ b/trip_app/core/utils.py
@@ -30,18 +30,25 @@ def str_to_geopoint(data):
         E.g. '23.4 23.5', '[23.4 23.5]', '(23.4 23.5)' would be converted into
         the same object Point(23.4, 23.5) """
     lon, lat = re.findall(r"[-+]?\d*\.?\d+|\d+", data)
-    if not -90 <= float(lon) <= 90:
-        raise ValidationError(
-            " Longitude coordinates should be in range -90...90 "
-        )
+    validate_geo_point(lat, lon)
+    return fromstr(f"POINT({lon} {lat})", srid=4326)
+
+
+def validate_geo_point(lat, lon):
+    """ Raise validation error on invalid coords """
     if not -180 <= float(lat) <= 180:
         raise ValidationError(
             " Latitude coordinates should be in range -180...180 "
         )
-    return fromstr(f"POINT({lon} {lat})", srid=4326)
+    if not -90 <= float(lon) <= 90:
+        raise ValidationError(
+            " Longitude coordinates should be in range -90...90 "
+        )
 
 
 def geocode_or_raise_validation_error(address):
+    """ Geocode given address.
+        Will raise an error if the attempt wasn't successfull. """
     geo_location = geolocator.geocode(f"{address}")
     if not geo_location:
         raise ValidationError(

--- a/trip_app/core/utils.py
+++ b/trip_app/core/utils.py
@@ -32,13 +32,11 @@ def str_to_geopoint(data):
 
         :raises: ValidationError: If incoming data can't be converted
         to float or if it doesn't fit into coordinates range """
-    try:
-        lat_str, lon_str = re.findall(r"[-+]?\d*\.?\d+|\d+", data)
-        lat, lon = float(lat_str), float(lon_str)
-    except ValueError:
+    latlon = re.findall(r"[-+]?\d*\.?\d+|\d+", data)
+    if not latlon:
         raise ValidationError(f"Cannot parse {data} into geo coordinates")
-    else:
-        validate_geo_point(lat, lon)
+    lat, lon = float(latlon[0]), float(latlon[1])
+    validate_geo_point(lat, lon)
     return Point(lat, lon, srid=4326)
 
 

--- a/trip_app/core/utils.py
+++ b/trip_app/core/utils.py
@@ -33,7 +33,7 @@ def str_to_geopoint(data):
         :raises: ValidationError: If incoming data can't be converted
         to float or if it doesn't fit into coordinates range """
     latlon = re.findall(r"[-+]?\d*\.?\d+|\d+", data)
-    if not latlon:
+    if len(latlon) != 2:
         raise ValidationError(f"Cannot parse {data} into geo coordinates")
     lat, lon = float(latlon[0]), float(latlon[1])
     validate_geo_point(lat, lon)

--- a/trip_app/core/utils.py
+++ b/trip_app/core/utils.py
@@ -23,11 +23,15 @@ def raise_for_status(resp):
         raise Exception(http_error_msg)
 
 
-def str_to_geopoint_or_validation_error(data):
+def str_to_geopoint(data):
     """ Convert string coordinates into a  Point object.
+
         Regex is used to handle different incoming formats.
         E.g. '23.4 23.5', '[23.4 23.5]', '(23.4 23.5)' would be converted into
-        the same object Point(23.4, 23.5). """
+        the same object Point(23.4, 23.5).
+
+        :raises: ValidationError: If incoming data can't be converted
+        to float or if it doesn't fit into coordinates range """
     try:
         lat_str, lon_str = re.findall(r"[-+]?\d*\.?\d+|\d+", data)
         lat, lon = float(lat_str), float(lon_str)
@@ -50,9 +54,10 @@ def validate_geo_point(lat, lon):
         )
 
 
-def geocode_or_validation_error(address):
+def geocode(address):
     """ Geocode given address.
-        Will raise an error if the attempt wasn't successfull. """
+
+        :raises: ValidationError: If data can't be geocoded. """
     geo_location = geolocator.geocode(f"{address}")
     if not geo_location:
         raise ValidationError(

--- a/trip_app/trip_app/settings/base.py
+++ b/trip_app/trip_app/settings/base.py
@@ -163,3 +163,5 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/2.2/howto/static-files/
 
 STATIC_URL = "/static/"
+
+OPEN_STREET_MAP_KEY = get_env_variable("OPENSTREET_KEY")

--- a/trip_app/trip_app/settings/local.py
+++ b/trip_app/trip_app/settings/local.py
@@ -12,20 +12,3 @@ DATABASES = {
 }
 
 SIMPLE_JWT["ACCESS_TOKEN_LIFETIME"] = timedelta(minutes=60)
-
-LOGGING = {
-    "version": 1,
-    "filters": {
-        "require_debug_true": {"()": "django.utils.log.RequireDebugTrue"}
-    },
-    "handlers": {
-        "console": {
-            "level": "DEBUG",
-            "filters": ["require_debug_true"],
-            "class": "logging.StreamHandler",
-        }
-    },
-    "loggers": {
-        "django.db.backends": {"level": "DEBUG", "handlers": ["console"]}
-    },
-}

--- a/trip_app/trips/models.py
+++ b/trip_app/trips/models.py
@@ -19,13 +19,13 @@ class Trip(models.Model):
     )
     dep_time = models.DateTimeField()
     price = models.DecimalField(max_digits=6, decimal_places=2)
-    start_point = models.OneToOneField(
+    start_point = models.ForeignKey(
         Location,
         related_name="start_point_of",
         on_delete=models.SET_NULL,
         null=True,
     )
-    dest_point = models.OneToOneField(
+    dest_point = models.ForeignKey(
         Location,
         related_name="dest_point_of",
         on_delete=models.SET_NULL,

--- a/trip_app/trips/models.py
+++ b/trip_app/trips/models.py
@@ -3,6 +3,11 @@ from django.contrib.gis.db import models as geo_models
 from django.db import models
 
 
+class Location(models.Model):
+    address = models.CharField(max_length=150, blank=True)
+    point = geo_models.PointField()
+
+
 class Trip(models.Model):
     driver = models.ForeignKey(
         settings.AUTH_USER_MODEL,
@@ -13,9 +18,19 @@ class Trip(models.Model):
         settings.AUTH_USER_MODEL, related_name="booked_trips"
     )
     dep_time = models.DateTimeField()
-    start_point = geo_models.PointField()
-    dest_point = geo_models.PointField()
     price = models.DecimalField(max_digits=6, decimal_places=2)
+    start_point = models.OneToOneField(
+        Location,
+        related_name="start_point_of",
+        on_delete=models.SET_NULL,
+        null=True,
+    )
+    dest_point = models.OneToOneField(
+        Location,
+        related_name="dest_point_of",
+        on_delete=models.SET_NULL,
+        null=True,
+    )
     num_seats = models.PositiveIntegerField()
     man_approve = models.BooleanField(default=True)
     description = models.TextField(blank=True)

--- a/trip_app/trips/serializers.py
+++ b/trip_app/trips/serializers.py
@@ -14,8 +14,20 @@ class LocationSerializer(GeoFeatureModelSerializer):
 
     point = geofields.GeometryField(required=False)
 
+    def validate_point(self, value):
+        """ Point field validation. """
+        if not -180 <= value.x <= 180:
+            raise ValidationError(
+                " Latitude coordinates should be in range -180...180 "
+            )
+        if not -90 <= value.y <= 90:
+            raise ValidationError(
+                " Longitude coordinates should be in range -90...90 "
+            )
+        return value
+
     def validate(self, attrs):
-        """ Object level validation
+        """ Object level validation.
 
             First verify that at least one location attribute is provided,
             if no geo coordinate is provided, verify that address can be
@@ -91,7 +103,7 @@ class TripSerializer(ModelSerializer):
 
     def create(self, validated_data):
         """ Overwrite the base create method in order to explicitly
-            specify how the child relationships should be saved.
+            handle nested serializers relationships.
             """
         start_point_data, dest_point_data = (
             validated_data.get("start_point"),
@@ -109,7 +121,7 @@ class TripSerializer(ModelSerializer):
 
     def update(self, instance, validated_data):
         """ Overwrite the base update method in order to explicitly
-            specify how the child relationships should be saved.
+            handle nested serializers relationships.
             """
         start_point_data, dest_point_data = (
             validated_data.get("start_point"),

--- a/trip_app/trips/serializers.py
+++ b/trip_app/trips/serializers.py
@@ -5,7 +5,7 @@ from rest_framework.serializers import ModelSerializer
 from rest_framework_gis import fields as geofields
 from rest_framework_gis.serializers import GeoFeatureModelSerializer
 
-from core.utils import geocode_or_raise_validation_error
+from core.utils import geocode_or_raise_validation_error, validate_geo_point
 from trips.models import Trip, TripRequest, Location
 
 
@@ -16,14 +16,7 @@ class LocationSerializer(GeoFeatureModelSerializer):
 
     def validate_point(self, value):
         """ Point field validation. """
-        if not -180 <= value.x <= 180:
-            raise ValidationError(
-                " Latitude coordinates should be in range -180...180 "
-            )
-        if not -90 <= value.y <= 90:
-            raise ValidationError(
-                " Longitude coordinates should be in range -90...90 "
-            )
+        validate_geo_point(value.x, value.y)
         return value
 
     def validate(self, attrs):

--- a/trip_app/trips/serializers.py
+++ b/trip_app/trips/serializers.py
@@ -5,7 +5,7 @@ from rest_framework.serializers import ModelSerializer
 from rest_framework_gis import fields as geofields
 from rest_framework_gis.serializers import GeoFeatureModelSerializer
 
-from core.utils import geocode_or_raise_validation_error, validate_geo_point
+from core.utils import geocode_or_validation_error, validate_geo_point
 from trips.models import Trip, TripRequest, Location
 
 
@@ -30,33 +30,29 @@ class LocationSerializer(GeoFeatureModelSerializer):
             raise ValidationError("Specify either address or geo coords")
         if not attrs.get("point"):
             address = attrs["address"]
-            geocode_or_raise_validation_error(address)
+            geocode_or_validation_error(address)
         return attrs
 
     def create(self, validated_data):
-        """ Override of the base create method
+        """ Override of the base create method.
 
             If no geo coordinate is provided, geocode the address and save
-            the model, otherwise just call base create() to save the model
+            the model, otherwise just call base create() to save the model.
             """
         if not validated_data.get("point"):
             address = validated_data["address"]
-            validated_data["point"] = geocode_or_raise_validation_error(
-                address
-            )
+            validated_data["point"] = geocode_or_validation_error(address)
         return super().create(validated_data)
 
     def update(self, instance, validated_data):
-        """ Override of the base update method
+        """ Override of the base update method.
 
             If no geo coordinate is provided, geocode the address and save
-            the model, otherwise just call base update() to update the model
+            the model, otherwise just call base update() to update the model.
             """
         if not validated_data.get("point"):
             address = validated_data["address"]
-            validated_data["point"] = geocode_or_raise_validation_error(
-                address
-            )
+            validated_data["point"] = geocode_or_validation_error(address)
         return super().update(instance, validated_data)
 
     class Meta:
@@ -138,11 +134,11 @@ class TripSerializer(ModelSerializer):
 
     def validate_dep_time(self, value):
         """
-        Check that the departure time is in the future
+        Check that the departure time is in the future.
         """
         if value < timezone.now():
             raise serializers.ValidationError(
-                "Departure time has expired. Please correct the time"
+                "Departure time has expired. Please correct the time."
             )
         return value
 

--- a/trip_app/trips/serializers.py
+++ b/trip_app/trips/serializers.py
@@ -1,30 +1,68 @@
 from django.utils import timezone
 from rest_framework import serializers
+from rest_framework.exceptions import ValidationError
 from rest_framework.serializers import ModelSerializer
+from rest_framework_gis import fields as geofields
+from rest_framework_gis.serializers import GeoFeatureModelSerializer
 
-from core.utils import str_to_geopoint
-from trips.models import Trip, TripRequest
+from core.utils import geocode_or_raise_validation_error
+from trips.models import Trip, TripRequest, Location
 
 
-class GeoField(serializers.CharField):
-    """
-    Geo objects to string and vice versa
-    """
+class LocationSerializer(GeoFeatureModelSerializer):
+    """ A class to serialize locations as GeoJSON compatible data """
 
-    def to_representation(self, value):
-        """ Convert Point object to string.
-            E.g. Point(23.4, 23.5) -> '[23.4 23.5]'. """
-        return f"{value.x} {value.y}"
+    point = geofields.GeometryField(required=False)
 
-    def to_internal_value(self, data):
-        """ Convert string coordinates in Point object.
-            E.g. '23.4 23.5'-> Point(23.4, 23.5). """
-        return str_to_geopoint(data)
+    def validate(self, attrs):
+        """ Object level validation
+
+            First verify that at least one location attribute is provided,
+            if no geo coordinate is provided, verify that address can be
+            geocoded.
+            """
+        if not any(value for value in attrs.values()):
+            raise ValidationError("Specify either address or geo coords")
+        if not attrs.get("point"):
+            address = attrs["address"]
+            geocode_or_raise_validation_error(address)
+        return attrs
+
+    def create(self, validated_data):
+        """ Override of the base create method
+
+            If no geo coordinate is provided, geocode the address and save
+            the model, otherwise just call base create() to save the model
+            """
+        if not validated_data.get("point"):
+            address = validated_data["address"]
+            validated_data["point"] = geocode_or_raise_validation_error(
+                address
+            )
+        return super().create(validated_data)
+
+    def update(self, instance, validated_data):
+        """ Override of the base update method
+
+            If no geo coordinate is provided, geocode the address and save
+            the model, otherwise just call base update() to update the model
+            """
+        if not validated_data.get("point"):
+            address = validated_data["address"]
+            validated_data["point"] = geocode_or_raise_validation_error(
+                address
+            )
+        return super().update(instance, validated_data)
+
+    class Meta:
+        model = Location
+        geo_field = "point"
+        fields = ("id", "address", "point")
 
 
 class TripSerializer(ModelSerializer):
-    dest_point = GeoField(required=True, max_length=100)
-    start_point = GeoField(required=True, max_length=100)
+    dest_point = LocationSerializer()
+    start_point = LocationSerializer()
     driver = serializers.StringRelatedField(read_only=True)
     passengers = serializers.StringRelatedField(read_only=True, many=True)
     dist1 = serializers.CharField(required=False, read_only=True)
@@ -50,6 +88,45 @@ class TripSerializer(ModelSerializer):
             "dist2",
         ]
         extra_kwargs = {"num_seats": {"write_only": True}}
+
+    def create(self, validated_data):
+        """ Overwrite the base create method in order to explicitly
+            specify how the child relationships should be saved.
+            """
+        start_point_data, dest_point_data = (
+            validated_data.get("start_point"),
+            validated_data.get("dest_point"),
+        )
+
+        validated_data["start_point"] = LocationSerializer().create(
+            validated_data=start_point_data
+        )
+        validated_data["dest_point"] = LocationSerializer().create(
+            validated_data=dest_point_data
+        )
+
+        return super().create(validated_data)
+
+    def update(self, instance, validated_data):
+        """ Overwrite the base update method in order to explicitly
+            specify how the child relationships should be saved.
+            """
+        start_point_data, dest_point_data = (
+            validated_data.get("start_point"),
+            validated_data.get("dest_point"),
+        )
+
+        if start_point_data:
+            validated_data["start_point"] = LocationSerializer().update(
+                instance=instance.start_point, validated_data=start_point_data
+            )
+
+        if dest_point_data:
+            validated_data["dest_point"] = LocationSerializer().update(
+                instance=instance.dest_point, validated_data=dest_point_data
+            )
+
+        return super().update(instance=instance, validated_data=validated_data)
 
     def get_free_seats(self, obj):
         return obj.free_seats

--- a/trip_app/trips/serializers.py
+++ b/trip_app/trips/serializers.py
@@ -5,7 +5,7 @@ from rest_framework.serializers import ModelSerializer
 from rest_framework_gis import fields as geofields
 from rest_framework_gis.serializers import GeoFeatureModelSerializer
 
-from core.utils import geocode_or_validation_error, validate_geo_point
+from core.utils import geocode, validate_geo_point
 from trips.models import Trip, TripRequest, Location
 
 
@@ -30,7 +30,7 @@ class LocationSerializer(GeoFeatureModelSerializer):
             raise ValidationError("Specify either address or geo coords")
         if not attrs.get("point"):
             address = attrs["address"]
-            geocode_or_validation_error(address)
+            geocode(address)
         return attrs
 
     def create(self, validated_data):
@@ -41,7 +41,7 @@ class LocationSerializer(GeoFeatureModelSerializer):
             """
         if not validated_data.get("point"):
             address = validated_data["address"]
-            validated_data["point"] = geocode_or_validation_error(address)
+            validated_data["point"] = geocode(address)
         return super().create(validated_data)
 
     def update(self, instance, validated_data):
@@ -52,7 +52,7 @@ class LocationSerializer(GeoFeatureModelSerializer):
             """
         if not validated_data.get("point"):
             address = validated_data["address"]
-            validated_data["point"] = geocode_or_validation_error(address)
+            validated_data["point"] = geocode(address)
         return super().update(instance, validated_data)
 
     class Meta:

--- a/trip_app/trips/tests/conftest.py
+++ b/trip_app/trips/tests/conftest.py
@@ -24,7 +24,7 @@ def trip_data():
             "point": {"type": "Point", "coordinates": [5.000000, 23.000000]}
         },
         "dest_point": {
-            "point": {"type": "Point", "coordinates": [5.000000, 23.000000]}
+            "point": {"type": "Point", "coordinates": [10.000000, 23.000000]}
         },
         "price": round(random.uniform(1, 10000), 2),
         "num_seats": faker.random_digit_not_null(),

--- a/trip_app/trips/tests/conftest.py
+++ b/trip_app/trips/tests/conftest.py
@@ -20,8 +20,12 @@ def trip_data():
         repr for using as a request payload """
     data = {
         "dep_time": (timezone.now() + timedelta(days=1)),
-        "start_point": f"{faker.latitude()} {faker.longitude()}",
-        "dest_point": f"{faker.latitude()} {faker.longitude()}",
+        "start_point": {
+            "point": {"type": "Point", "coordinates": [5.000000, 23.000000]}
+        },
+        "dest_point": {
+            "point": {"type": "Point", "coordinates": [5.000000, 23.000000]}
+        },
         "price": round(random.uniform(1, 10000), 2),
         "num_seats": faker.random_digit_not_null(),
         "description": "test description",

--- a/trip_app/trips/tests/test_validations.py
+++ b/trip_app/trips/tests/test_validations.py
@@ -6,7 +6,10 @@ from django.urls import reverse
 from django.utils import timezone
 from rest_framework.exceptions import ValidationError
 
-from core.utils import str_to_geopoint, geocode_or_raise_validation_error
+from core.utils import (
+    str_to_geopoint_or_validation_error,
+    geocode_or_validation_error,
+)
 from trips.serializers import LocationSerializer
 
 MAX_LONGITUDE = 90.0
@@ -60,7 +63,7 @@ def test_invalid_dep_time(admin_client, trip_data):
 def test_convert_to_geopoint(str_coord):
     """ Verify 'str_to_geopoint' function that is responsible for serializing
     incoming string coordinates to django.contrib.gis.geos.Point objects. """
-    point = str_to_geopoint(str_coord)
+    point = str_to_geopoint_or_validation_error(str_coord)
     assert point == Point(23.5, 23.5, srid=4326)
     assert point.x == 23.5
     assert point.y == 23.5
@@ -79,7 +82,7 @@ def test_convert_to_geopoint(str_coord):
 )
 def test_geocode(address):
     """ Verify 'geocode_or_raise_validation_error' can geocode address. """
-    point = geocode_or_raise_validation_error(address)
+    point = geocode_or_validation_error(address)
     assert point
 
 
@@ -90,7 +93,7 @@ def test_invalid_geocode(invalid_address):
     """ Verify that 'geocode_or_raise_validation_error' function
         raises Validation error for invalid address. """
     with pytest.raises(ValidationError) as exc:
-        geocode_or_raise_validation_error(invalid_address)
+        geocode_or_validation_error(invalid_address)
     assert f"We can't geocode address: {invalid_address}" in str(exc.value)
 
 

--- a/trip_app/trips/tests/test_validations.py
+++ b/trip_app/trips/tests/test_validations.py
@@ -30,13 +30,15 @@ list_create_trips_url = reverse("trips-list")
 def test_incorrect_coords(admin_client, incorrect_coords, trip_data):
     """ Verify that Trip can't be created having incorrect coordinate """
     longitude, latitude, incorrect_arg = incorrect_coords
-    start_point = f"{longitude}, {latitude}"
-    trip_data["start_point"] = start_point
-    resp = admin_client.post(list_create_trips_url, trip_data)
+    start_point = f"POINT({latitude} {longitude})"
+    trip_data["start_point"]["point"] = start_point
+    resp = admin_client.post(
+        list_create_trips_url, trip_data, content_type="application/json"
+    )
     assert resp.status_code == 400
     assert (
         f"{incorrect_arg} coordinates should be in range "
-        in resp.json()["start_point"][0]
+        in resp.json()["start_point"]["point"][0]
     )
 
 

--- a/trip_app/trips/tests/test_validations.py
+++ b/trip_app/trips/tests/test_validations.py
@@ -6,10 +6,7 @@ from django.urls import reverse
 from django.utils import timezone
 from rest_framework.exceptions import ValidationError
 
-from core.utils import (
-    str_to_geopoint_or_validation_error,
-    geocode_or_validation_error,
-)
+from core.utils import str_to_geopoint, geocode
 from trips.serializers import LocationSerializer
 
 MAX_LONGITUDE = 90.0
@@ -63,7 +60,7 @@ def test_invalid_dep_time(admin_client, trip_data):
 def test_convert_to_geopoint(str_coord):
     """ Verify 'str_to_geopoint' function that is responsible for serializing
     incoming string coordinates to django.contrib.gis.geos.Point objects. """
-    point = str_to_geopoint_or_validation_error(str_coord)
+    point = str_to_geopoint(str_coord)
     assert point == Point(23.5, 23.5, srid=4326)
     assert point.x == 23.5
     assert point.y == 23.5
@@ -82,7 +79,7 @@ def test_convert_to_geopoint(str_coord):
 )
 def test_geocode(address):
     """ Verify 'geocode_or_raise_validation_error' can geocode address. """
-    point = geocode_or_validation_error(address)
+    point = geocode(address)
     assert point
 
 
@@ -93,7 +90,7 @@ def test_invalid_geocode(invalid_address):
     """ Verify that 'geocode_or_raise_validation_error' function
         raises Validation error for invalid address. """
     with pytest.raises(ValidationError) as exc:
-        geocode_or_validation_error(invalid_address)
+        geocode(invalid_address)
     assert f"We can't geocode address: {invalid_address}" in str(exc.value)
 
 

--- a/trip_app/trips/tests/trip_factory.py
+++ b/trip_app/trips/tests/trip_factory.py
@@ -7,9 +7,19 @@ from django.utils import timezone
 from faker import Factory as FakerFactory
 
 from accounts.tests.user_factory import UserFactory
-from trips.models import Trip
+from trips.models import Trip, Location
 
 faker = FakerFactory.create()
+
+
+class LocationFactory(factory.django.DjangoModelFactory):
+    """ Location factory. """
+
+    address = faker.address()
+    point = Point(float(faker.latitude()), float(faker.longitude()), srid=4326)
+
+    class Meta:
+        model = Location
 
 
 class TripFactory(factory.django.DjangoModelFactory):
@@ -17,12 +27,8 @@ class TripFactory(factory.django.DjangoModelFactory):
 
     driver = factory.SubFactory(UserFactory)
     dep_time = timezone.now() + timedelta(days=1)
-    start_point = Point(
-        float(faker.latitude()), float(faker.longitude()), srid=4326
-    )
-    dest_point = Point(
-        float(faker.latitude()), float(faker.longitude()), srid=4326
-    )
+    start_point = factory.SubFactory(LocationFactory)
+    dest_point = factory.SubFactory(LocationFactory)
     price = round(random.uniform(1, 10000), 2)
     num_seats = faker.random_digit_not_null()
     description = "test description"

--- a/trip_app/trips/views.py
+++ b/trip_app/trips/views.py
@@ -43,19 +43,21 @@ class TripViewSet(ModelViewSet):
         point2 = query_params.get("point2")
         address1 = query_params.get("addr1")
         address2 = query_params.get("addr2")
-        try:
-            geo_point1, geo_point2 = None, None
-            if point1 and point2:
-                geo_point1 = str_to_geopoint(point1)
-                geo_point2 = str_to_geopoint(point2)
-            elif address1 and address2:
-                geo_point1 = geocode_or_raise_validation_error(address1)
-                geo_point2 = geocode_or_raise_validation_error(address2)
-        except ValidationError:
-            # return empty queryset
-            return Trip.objects.none()
-        else:
-            if geo_point1 and geo_point2:
+        geo_coords = bool(point1 and point2)
+        address_coords = bool(address1 and address2)
+
+        if geo_coords or address_coords:
+            try:
+                if geo_coords:
+                    geo_point1 = str_to_geopoint(point1)
+                    geo_point2 = str_to_geopoint(point2)
+                elif address_coords:
+                    geo_point1 = geocode_or_raise_validation_error(address1)
+                    geo_point2 = geocode_or_raise_validation_error(address2)
+            except ValidationError:
+                # return empty queryset
+                return Trip.objects.none()
+            else:
                 # Annotate queryset with 2 attributes:
                 # dist1 - distance between user and trip start point;
                 # dist2 - between user and trip end point.

--- a/trip_app/trips/views.py
+++ b/trip_app/trips/views.py
@@ -42,9 +42,10 @@ class TripViewSet(ModelViewSet):
         point2 = query_params.get("point2")
         address1 = query_params.get("addr1")
         address2 = query_params.get("addr2")
-        geo_coords = bool(point1 and point2)
-        address_coords = bool(address1 and address2)
+        geo_coords = all([point1, point2])
+        address_coords = all([address1, address2])
         if geo_coords or address_coords:
+            # TODO: Consider possibility of using factory pattern here
             if geo_coords:
                 geo_point1 = str_to_geopoint(point1)
                 geo_point2 = str_to_geopoint(point2)

--- a/trip_app/trips/views.py
+++ b/trip_app/trips/views.py
@@ -8,7 +8,10 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.viewsets import ModelViewSet
 
-from core.utils import str_to_geopoint, geocode_or_raise_validation_error
+from core.utils import (
+    str_to_geopoint_or_validation_error,
+    geocode_or_validation_error,
+)
 from trips.models import Trip, TripRequest
 from trips.permissions import IsTripDriverOrAdmin
 from trips.serializers import TripSerializer, TripRequestSerializer
@@ -49,11 +52,11 @@ class TripViewSet(ModelViewSet):
         if geo_coords or address_coords:
             try:
                 if geo_coords:
-                    geo_point1 = str_to_geopoint(point1)
-                    geo_point2 = str_to_geopoint(point2)
+                    geo_point1 = str_to_geopoint_or_validation_error(point1)
+                    geo_point2 = str_to_geopoint_or_validation_error(point2)
                 elif address_coords:
-                    geo_point1 = geocode_or_raise_validation_error(address1)
-                    geo_point2 = geocode_or_raise_validation_error(address2)
+                    geo_point1 = geocode_or_validation_error(address1)
+                    geo_point2 = geocode_or_validation_error(address2)
             except ValidationError:
                 # return empty queryset
                 return Trip.objects.none()


### PR DESCRIPTION
In this PR:
- Added Location model which contains 2 fields: address(str) and point(geo field) and has M:1 relation with Trip model. New model was introduced to support work with trips via string view addresses (previously it was possible to feed API only with geo coordinates ). 
So in general now you can create/find trip using human readable addresses along with old coordinates approach. 
 It is possible thanks to the new added geopy library. I'm using geolocation service Nominatim, which abstracts the OpenStreetMap service’s API. 
- Added Location serializer derived from rest_framework_gis.serializers.GeoFeatureModelSerializer. I choose using 'rest_framework_gis' library because it  outputs data in a format that is GeoJSON compatible which is sort of standard now.
- Fixed old tests that failed due to model changes and added some new.
